### PR TITLE
Use margin container instead of control to avoid overlap

### DIFF
--- a/addons/editor_physics/PhysicsControl.tscn
+++ b/addons/editor_physics/PhysicsControl.tscn
@@ -2,20 +2,18 @@
 
 [ext_resource path="res://addons/editor_physics/PhysicsControl.gd" type="Script" id=1]
 
-[node name="ButtonControl" type="Control"]
+[node name="ButtonControl" type="MarginContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ToolButton" type="ToolButton" parent="."]
-margin_right = 12.0
-margin_bottom = 22.0
+margin_right = 1024.0
+margin_bottom = 600.0
 hint_tooltip = "Toggle Physics"
 toggle_mode = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
 [connection signal="toggled" from="ToolButton" to="." method="_on_CheckButton_toggled"]


### PR DESCRIPTION
**Before Change**: if another plugin adds to the editor menu it overlaps the toggle button
![error_before](https://user-images.githubusercontent.com/40386587/191574512-b77d1520-a02c-421e-8fbf-b7ef6a2b5053.jpg)

**After Change**: they do not overlap
![after_change](https://user-images.githubusercontent.com/40386587/191574520-183afda8-ddf7-4d25-9ca3-1e76171d5a0c.jpg)
